### PR TITLE
Require phpstan/phpstan ^0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "require": {
         "php": "^7.1",
         "friendsofsymfony/http-cache-bundle": "^2.6",
-        "phpstan/phpstan": "^0.10.2",
-        "phpstan/phpstan-symfony": "^0.10.2",
+        "phpstan/phpstan": "^0.11",
+        "phpstan/phpstan-symfony": "^0.11",
         "symfony/debug": "^4.1",
         "symfony/monolog-bridge": "^4.1",
         "symfony/monolog-bundle": "^3.3",


### PR DESCRIPTION
Should give a new release: `0.5.0`. See also following PR: https://github.com/contao/contao/pull/319