### PR TITLE
Remove deprecated option logout_on_user_change

### DIFF
--- a/src/Resources/config/security.yml
+++ b/src/Resources/config/security.yml
@@ -26,7 +26,6 @@ security:
             user_checker: contao.security.user_checker
             anonymous: ~
             switch_user: true
-            logout_on_user_change: true
 
             contao_login:
                 login_path: contao_backend_login
@@ -53,7 +52,6 @@ security:
             user_checker: contao.security.user_checker
             anonymous: ~
             switch_user: false
-            logout_on_user_change: true
 
             contao_login:
                 login_path: contao_frontend_login


### PR DESCRIPTION
Since we implement the `EquatableInterface` on our `User`:
symfony.com/doc/current/reference/configuration/security.html#logout-on-user-change

see also https://github.com/contao/contao/pull/497