### PR TITLE
Use bootstrapFiles instead of bootstrap

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -3,7 +3,8 @@ parameters:
         - Contao\Model
         - Contao\Templates
 
-    bootstrap: bootstrap.php
+    bootstrapFiles:
+        - bootstrap.php
 
 parametersSchema:
     contao: structure([


### PR DESCRIPTION
```
⚠️  You're using a deprecated config option bootstrap. ⚠️️

This option has been replaced with bootstrapFiles which accepts a list of files
to execute before the analysis.
```